### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ guide.
 Make sure you have access to PSPDFKit either as a customer or by signing up for
 a [free trial](https://pspdfkit.com/try/).
 
-### Using Cocoapods
+### Using CocoaPods
 
-We assume you are familiar with [Cocoapods](https://cocoapods.org), otherwise
+We assume you are familiar with [CocoaPods](https://cocoapods.org), otherwise
 please consult the documentation first. You'll have to add PSPDFKit as well as
 PDFXKit as a dependency to your `Podfile`.
 
@@ -98,7 +98,7 @@ Next you'll have to adapt your project to use PDFXKit as described in Section
 ### Manual Set-Up
 
 **Note:** manual set-up is only for experts, we assume you know what you are
-doing. If you are unsure, please use Cocoapods or Carthage instead.
+doing. If you are unsure, please use CocoaPods or Carthage instead.
 
 First, build the PDFXKit framework:
 


### PR DESCRIPTION

This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).
