### PR TITLE
Update for PSPDFKit 9.4 for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PDFXKit is a drop-in replacement for [Apple
 PDFKit](https://developer.apple.com/documentation/pdfkit) using the industry
 leading [PSPDFKit](http://pspdfkit.com) framework under the hood. The latest
 version requires [PSPDFKit 9 for
-iOS](https://pspdfkit.com/blog/2019/pspdfkit-ios-9/) and Xcode 11.
+iOS](https://pspdfkit.com/blog/2019/pspdfkit-ios-9/) and Xcode 11.5.
 
 [![](https://pspdfkit.com/images/blog/2017/pdfxkit/pdfxkit-7b7a75f5.png)](https://pspdfkit.com/blog/2017/introducing-pdfxkit/)
 
@@ -55,16 +55,12 @@ PDFXKit as a dependency to your `Podfile`.
 target :YourAppName do
   use_frameworks!
 
-  # Replace `YOUR_COCOAPODS_KEY` with your own.
-  pod 'PSPDFKit', podspec: 'https://customers.pspdfkit.com/cocoapods/YOUR_COCOAPODS_KEY/latest.podspec'
+  pod 'PSPDFKit', podspec: 'https://customers.pspdfkit.com/pspdfkit-ios/latest-framework.podspec'
   pod 'PDFXKit', :git => "git@github.com:PSPDFKit/PDFXKit.git", :branch => "master"
 end
 ```
 
-**Note:** make sure to replace `YourAppName` with your app name and
-`YOUR_COCOAPODS_KEY` with your own key provided by PSPDFKit GmbH. You can find
-your key either in [customer portal](https://customers.pspdfkit.com/) or by
-requesting an [evaluation license](https://pspdfkit.com/try/).
+**Note:** make sure to replace `YourAppName` with your actual app name.
 
 Now run `pod install`. Afterwards you should be able to build & run your project
 without errors. Next you'll have to adapt your project to use PDFXKit as
@@ -79,20 +75,14 @@ a dependency to your `Cartfile`.
 
 --------------------------------------------------------------------------------
 
-*PDFXKit requires Xcode 11 and later.*
+*PDFXKit requires Xcode 11.5 and later.*
 
 --------------------------------------------------------------------------------
 
 ``` Ruby
-# Replace YOUR_COCOAPODS_KEY with your own
-binary "https://customers.pspdfkit.com/carthage/YOUR_COCOAPODS_KEY/PSPDFKit.json"
+binary "https://customers.pspdfkit.com/pspdfkit-ios.json"
 git "git@github.com:PSPDFKit/PDFXKit.git" "master"
 ```
-
-**Note:** make sure to replace `YOUR_COCOAPODS_KEY` with your own key provided
-by PSPDFKit GmbH. You can find your key either in [customer
-portal](https://customers.pspdfkit.com/) or by requesting an
-[evaluation license](https://pspdfkit.com/try/).
 
 Now follow the regular [Carthage setup routine](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos)
 to add `PSPDFKit.framework`, `PSPDFKitUI.framework`, and `PDFXKit.framework` as a dependency to your
@@ -108,7 +98,7 @@ doing. If you are unsure, please use CocoaPods or Carthage instead.
 First, build the PDFXKit framework:
 
 * Clone `git@github.com:PSPDFKit/PDFXKit.git`
-* Replace `COCOAPODS_KEY` with your key and download the following the fat frameworks from here: https://customers.pspdfkit.com/cocoapods/COCOAPODS_KEY/pspdfkit/latest.zip
+* Download the PSPDFKit fat frameworks from here: https://customers.pspdfkit.com/pspdfkit-ios/latest-framework.zip
 * Extract the zip file you downloaded and copy `PSPDFKit.framework` and `PSPDFKitUI.framework` into `PDFXKit/Frameworks`
 * Open the terminal and `cd` into the `PDFXKit` directory
 * Run `rake compile`
@@ -178,7 +168,7 @@ annotated with the `PDFX_NOT_IMPLEMENTED_PRIORITY_...` and
 If you want to work on PDFXKit, perform the following steps:
 
 * Clone `git@github.com:PSPDFKit/PDFXKit.git`
-* Replace `COCOAPODS_KEY` with your key and download the following the fat frameworks from here: https://customers.pspdfkit.com/cocoapods/COCOAPODS_KEY/pspdfkit/latest.zip
+* Download the PSPDFKit fat frameworks from here: https://customers.pspdfkit.com/latest-framework.zip
 * Extract the zip file you downloaded and copy `PSPDFKit.framework` and `PSPDFKitUI.framework` into `PDFXKit/Frameworks`
 * Open `PDFXKit.xcodeproj` in Xcode
 * Build & Run `PDFXKitExample` (iOS)

--- a/Rakefile
+++ b/Rakefile
@@ -51,8 +51,8 @@ VERBOSE = ENV['verbose'] || false
 
 # ------------------------------------------------------------- Constants ------
 
-SDK_SIM = "iphonesimulator13.4"
-SDK_IOS = "iphoneos13.4"
+SDK_SIM = "iphonesimulator13.5"
+SDK_IOS = "iphoneos13.5"
 XCODE_FLAGS = "-configuration Release -scheme PDFXKit -derivedDataPath \"#{DIRECTORY}/Xcode\""
 
 # ---------------------------------------------------------------- Colors ------


### PR DESCRIPTION
⚠️ Only merge after PSPDFKit 9.4 for iOS is released ⚠️ 

---

# Details

This PR updates for the upcoming PSPDFKit 9.4 release.

# Acceptance Criteria

- [x] The README is updated.
- [x] The `PDFXKitExample` app works great on both simulator and device.
- [x] `rake compile` works
- [x] The CocoaPods integration works in a sample project.
- [x] The Carthage integration works in a sample project.
