### PR TITLE
Update PDFXView to not disable translating autoresizing masks

### DIFF
--- a/Sources/PDFXKitObjC/ObjC/PDFXView.m
+++ b/Sources/PDFXKitObjC/ObjC/PDFXView.m
@@ -57,8 +57,6 @@ NSNotificationName const PSPDFViewControllerDidChangePageNotification = @"PSPDFV
 
 // @private common init used used for regular initialization and NSCoding.
 - (void)PDFXViewLoad {
-    self.translatesAutoresizingMaskIntoConstraints = NO;
-
     _pspdfViewController = [self makePSPDFViewController];
     _pspdfViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
     _pspdfViewController.delegate = self;


### PR DESCRIPTION
This PR updates the `PDFXView` to not disable its `translatesAutoresizingMaskIntoConstraints` to `NO`. This matches the default behavior of UIKit.